### PR TITLE
feat: add auto cert renewal docs, config, and hook

### DIFF
--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,5 +1,7 @@
 # Deployment
 
+- [Automatic Certificate Renewal](./certificate-renewal.md)
+
 ## Deploying to production
 `Deploy to Production` GitHub Action provides a semi-automatic way to deploy new ACC III version, implemented [here](../../.github/workflows/deploy.yml). It connects to the server via SSH and rebuilds the configured containers using `docker compose`. It is triggered on `workflow_dispatch` (i.e., manual trigger).
 

--- a/docs/deployment/certificate-renewal.md
+++ b/docs/deployment/certificate-renewal.md
@@ -1,0 +1,38 @@
+# Certificate Renewal
+The following doc describes a way to automatically renew SSL certificates using `certbot` and `systemd`.
+
+## Systemd Configuration
+Certbot relies on `certbot.timer` and `certbot.service` services to automatically renew certificates. Verify that both are running on your system: 
+
+```bash
+$ sudo systemctl status certbot.timer
+$ sudo systemctl status certbot.service
+
+# List running certbot timers:
+$ sudo systemctl list-timers | grep certbot
+```
+
+### Webroot Configuration
+So that we don't have to stop the nginx container to free up the port 80 (used by certbot for certificate renewal), we can configure it to use `webroot` authenticator instead.
+
+Use the configuration from [domain.conf](/deployment/certificates/renewal/domain.conf) in `/etc/letsencrypt/renewal/<your-domain>.conf` on your system.
+
+This will use the already running nginx for verification, instead of spinning up a temporary HTTP server in the case of `standalone` authenticator.
+
+## Reloading Nginx
+Once the certificate is renewed (deployed) we need to reload Nginx configuration. This can be achieved with the `deploy` certbot hook. Add the [reload-nginx.sh](/deployment/certificates/renewal-hooks/deploy/reload-nginx.sh) script to the `renewal-hooks` directory on your system:
+```bash
+$ cp deployment/certificates/renewal-hooks/deploy/reload-nginx.sh /etc/letsencrypt/renewal-hooks/deploy
+$ chmod +x /etc/letsencrypt/renewal-hooks/deploy
+```
+
+> _Note:_ Don't forget to adjust the path to the `docker-compose.yml` file on your system, if it differs.
+
+## Testing 
+To test if the setup works, you can force the certificate renewal:
+
+```bash
+$ sudo certbot renew --cert-name <your-domain> --force-renew
+```
+
+If everything worked as expected, you should see the new certificate (e.g. when navigating to the page).

--- a/src/deployment/certificates/renewal-hooks/deploy/reload-nginx.sh
+++ b/src/deployment/certificates/renewal-hooks/deploy/reload-nginx.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+NGINX_CONTAINER_NAME=$(docker ps --format "{{.Names}}" | grep nginx)
+
+if [[ -z "$NGINX_CONTAINER_NAME" ]]; then
+    echo "No nginx container found"
+    exit 1
+fi
+
+if docker exec "$NGINX_CONTAINER_NAME" nginx -s reload 2> /dev/null; then
+    echo "Successfully reloaded nginx"
+else
+    echo "Unable to reload nginx"
+    exit 1
+fi

--- a/src/deployment/certificates/renewal/domain.conf
+++ b/src/deployment/certificates/renewal/domain.conf
@@ -1,0 +1,4 @@
+# Options used in the renewal process
+[renewalparams]
+authenticator = webroot
+webroot_path = /var/www/certbot

--- a/src/deployment/docker-compose.prod.yml
+++ b/src/deployment/docker-compose.prod.yml
@@ -7,6 +7,7 @@ services:
       - "443:443"
     volumes:
       - /etc/letsencrypt:/etc/letsencrypt
+      - /var/www/certbot:/var/www/certbot
       - /home/ubuntu/AtomicChargeCalculator/src/deployment/nginx/${NGINX_CONFIG_FILE:-nginx.prod.conf}:/etc/nginx/nginx.conf
       - /home/ubuntu/AtomicChargeCalculator/src/deployment/nginx/snippets:/etc/nginx/snippets
     networks:

--- a/src/deployment/nginx/nginx.dev.conf
+++ b/src/deployment/nginx/nginx.dev.conf
@@ -67,7 +67,9 @@ http {
             root /var/www/certbot;
         }
 
-        return 301 https://acc-dev.biodata.ceitec.cz$request_uri;
+        location / {
+            return 301 https://acc-dev.biodata.ceitec.cz$request_uri;
+        }
     }
 
     server {

--- a/src/deployment/nginx/nginx.dev.conf
+++ b/src/deployment/nginx/nginx.dev.conf
@@ -59,6 +59,13 @@ http {
     server {
         listen 80;
         server_name acc-dev.biodata.ceitec.cz;
+        
+        ## 
+        # Handling of certificate renewal
+        ##
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
 
         return 301 https://acc-dev.biodata.ceitec.cz$request_uri;
     }

--- a/src/deployment/nginx/nginx.prod.conf
+++ b/src/deployment/nginx/nginx.prod.conf
@@ -60,7 +60,16 @@ http {
         listen 80;
         server_name acc.biodata.ceitec.cz acc2.ncbr.muni.cz;
 
-        return 301 https://acc.biodata.ceitec.cz$request_uri;
+        ## 
+        # Handling of certificate renewal
+        ##
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+
+        location / {
+            return 301 https://acc.biodata.ceitec.cz$request_uri;
+        }
     }
 
     server {


### PR DESCRIPTION
**Added**
- docs for auto certificate renewal (using certbot and systemd)
- deploy hook which reloads nginx configuration
- nginx location for serving acme challenge for domain ownership verification
- bare minimum configuration for the renewal service

Development environment is already set up.